### PR TITLE
[MLP-2242] - Buffered Messages

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -9,5 +9,5 @@ store the current version info of the notebook.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (5, 7, 9,'dev4')
+version_info = (5, 7, 9,'dev5')
 __version__ = '.'.join(map(str, version_info[:5])) + ''.join(version_info[5:])

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -216,6 +216,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         self._kernel_info_future = Future()
         self._close_future = Future()
         self.session_key = ''
+        self.buffer_key = ''
 
         # Rate limiting code
         self._iopub_window_msg_count = 0
@@ -238,6 +239,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         # servers never respond to websocket connection requests.
         kernel = self.kernel_manager.get_kernel(self.kernel_id)
         self.session.key = kernel.session.key
+        self.buffer_key = cast_unicode(kernel.session.key, "utf-8")  # Use kernel's session key for buffer replay id
         future = self.request_kernel_info()
         
         def give_up():
@@ -277,9 +279,9 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         km.notify_connect(kernel_id)
 
         # on new connections, flush the message buffer
-        buffer_info = km.get_buffer(kernel_id, self.session_key)
-        if buffer_info and buffer_info['session_key'] == self.session_key:
-            self.log.info("Restoring connection for %s", self.session_key)
+        buffer_info = km.get_buffer(kernel_id, self.buffer_key)
+        if buffer_info and buffer_info['session_key'] == self.buffer_key:
+            self.log.info("Restoring connection for kernel_id %s", self.kernel_id)
             self.channels = buffer_info['channels']
             replay_buffer = buffer_info['buffer']
             if replay_buffer:
@@ -456,7 +458,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
 
             # start buffering instead of closing if this was the last connection
             if km._kernel_connections[self.kernel_id] == 0:
-                km.start_buffering(self.kernel_id, self.session_key, self.channels)
+                km.start_buffering(self.kernel_id, self.buffer_key, self.channels)
                 self._close_future.set_result(None)
                 return
 

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -199,7 +199,7 @@ class MappingKernelManager(MultiKernelManager):
                 stream.close()
             return
 
-        self.log.info("Starting buffering for %s", session_key)
+        self.log.info("Starting buffering for kernel_id %s with session_key %s", kernel_id, session_key)
         self._check_kernel_id(kernel_id)
         # clear previous buffering state
         self.stop_buffering(kernel_id)
@@ -230,7 +230,7 @@ class MappingKernelManager(MultiKernelManager):
             If the session_key matches the current buffered session_key,
             the buffer will be returned.
         """
-        self.log.debug("Getting buffer for %s", kernel_id)
+        self.log.debug("Getting buffer for kernel_id %s with session_key %s", kernel_id, session_key)
         if kernel_id not in self._kernel_buffers:
             return
 
@@ -251,7 +251,7 @@ class MappingKernelManager(MultiKernelManager):
         kernel_id : str
             The id of the kernel to stop buffering.
         """
-        self.log.debug("Clearing buffer for %s", kernel_id)
+        self.log.debug("Clearing buffer for kernel_id %s", kernel_id)
         self._check_kernel_id(kernel_id)
 
         if kernel_id not in self._kernel_buffers:
@@ -265,8 +265,8 @@ class MappingKernelManager(MultiKernelManager):
 
         msg_buffer = buffer_info['buffer']
         if msg_buffer:
-            self.log.info("Discarding %s buffered messages for %s",
-                len(msg_buffer), buffer_info['session_key'])
+            self.log.info("Discarding %s buffered messages for kernel_id %s with session_key %s",
+                          len(msg_buffer), kernel_id, buffer_info['session_key'])
 
     def shutdown_kernel(self, kernel_id, now=False):
         """Shutdown a kernel by kernel_id"""

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "5.7.9.dev.4";
+    Jupyter.version = "5.7.9.dev5";
     Jupyter._target = '_blank';
     return Jupyter;
 });


### PR DESCRIPTION
Using Kernel manager's session_key instead of ZMQChannel's session_key as buffer_key.
This ensures that the session key remains the same on creating a new websocket connection for the same kernel. 
With this change, the buffered messages get replayed to the client. 

This notebook package should present in both hunch environment and JEG's environment

Note:- With this change, connecting multiple clients to the same kernel functionality should be deprecated 